### PR TITLE
Fixing Issue 33: Background Image is not applied

### DIFF
--- a/chrome.manifest
+++ b/chrome.manifest
@@ -21,3 +21,4 @@ locale  imagetweak tr    locale/tr/
 locale  imagetweak uk    locale/uk/
 locale  imagetweak zh-CN locale/zh-CN/
 locale  imagetweak zh-TW locale/zh-TW/
+override chrome://global/skin/media/TopLevelImageDocument.css chrome://imagetweak/skin/TopLevelImageDocument.css

--- a/skin/TopLevelImageDocument.css
+++ b/skin/TopLevelImageDocument.css
@@ -1,0 +1,21 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+@media not print {
+  /* N.B.: Remember to update ImageDocument.css in the tree or reftests may fail! */
+
+  body {
+    color: #222
+	background-image: none;
+  }
+
+  img.decoded{
+	background: transparent;
+  }
+  
+  img.transparent {
+    background: none;
+    color: #222;
+  }
+}


### PR DESCRIPTION
Background issue can be fixed by overriding the default TopLevelImageDocument.css with a custom one that doesn't include the background image. In addition, transparent images now show the user-specified background, and not the default white background.
